### PR TITLE
Allow DB password to be set independently

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -15,3 +15,4 @@ test:
 
 production:
   url: <%= ENV["DATABASE_URL"] %>
+  password: <%= ENV['DATABASE_PASSWORD'] %>


### PR DESCRIPTION
I want to separate DB password from DATABASE_URL env for Cookpad's internal use. This pull request uses DATABASE_PASSWORD env for the password.

@cookpad/infra Would you please review?