### PR TITLE
rubocop: Let rubocop search .ruby-version file

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,7 +10,7 @@ Style:
 Layout/EmptyLineAfterGuardClause:
   Enabled: false
 
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false
 
 Metrics/AbcSize:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,4 @@
 AllCops:
-  TargetRubyVersion: 2.3
   Exclude:
     - 'vendor/**/*'
     - 'tmp/**/*'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,14 +16,14 @@ Layout/LineLength:
 Metrics/AbcSize:
   Enabled: false
 
-Metrics/ClassLength:
+Metrics/BlockLength:
   Enabled: false
 
-Metrics/ModuleLength:
+Metrics/ClassLength:
   Enabled: false
 
 Metrics/MethodLength:
   Enabled: false
 
-Metrics/BlockLength:
+Metrics/ModuleLength:
   Enabled: false


### PR DESCRIPTION
Rubocop warns its `TargetRubyVersion` is too old, so I just removed it and let rubocop search `.ruby-version`.