### PR TITLE
fix: DataSource does not have db_name, but dbname

### DIFF
--- a/spec/requests/table_memos_spec.rb
+++ b/spec/requests/table_memos_spec.rb
@@ -21,7 +21,7 @@ describe :table_memos, type: :request do
       get database_schema_table_path(database_memo.name, schema_memo.name, table_memo.name)
       expect(response).to render_template("table_memos/show")
       expect(table_memo).to eq(assigns(:table_memo))
-      %w(id name description adapter host port db_name user).each {|attr| expect(page).to have_content(data_source[attr]) }
+      %w(id name description adapter host port dbname user).each { |attr| expect(page).to have_content(data_source.public_send(attr)) }
       expect(page).not_to have_content(/\d+:\d+:\d+ UTC/)
     end
 


### PR DESCRIPTION
This patch fixes the following warning which is shown when running rspec:

> Checking for expected text of nil is confusing and/or pointless since it will always match. Please specify a string or regexp instead.
