### PR TITLE
Remove references to old Docker repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,28 +20,20 @@ $ bundle exec foreman start
 
 ### Docker
 
-Docker images are published on Docker Hub.
-https://hub.docker.com/r/hogelog/dmemo/
-
 ```
+$ docker build . -t dmemo
 $ cp .env.production.sample .env.docker
 $ # Set all environment variables.
 $ # You can generate secret_key_base by the following command:
-$ #   `docker run --rm --env-file .env.docker -t hogelog/dmemo ./bin/rake secret`
+$ #   `docker run --rm --env-file .env.docker -t dmemo ./bin/rake secret`
 $ vi .env.docker
-$ docker run --rm --env-file .env.docker -t hogelog/dmemo ./bin/docker_db_apply.sh
-$ docker-compose up
+$ docker run --rm --env-file .env.docker -t dmemo ./bin/docker_db_apply.sh
+$ docker compose up
 ```
 
 ## Execute synchronization
 ```
 ./bin/rails r 'SynchronizeDataSources.run'
-```
-
-or
-
-```
-docker run --rm --env-file .env.docker -t hogelog/dmemo ./bin/rails r 'SynchronizeDataSources.run'
 ```
 
 
@@ -50,9 +42,7 @@ docker run --rm --env-file .env.docker -t hogelog/dmemo ./bin/rails r 'Synchroni
 - Login dmemo by google account
 - Activate user as admin
 ```
-$ ./bin/rake admin:activate EMAIL=konbu.komuro@gmail.com
- or
-$ docker run --env-file .env.docker hogelog/dmemo ./bin/docker_admin_activate.sh konbu.komuro@gmail.com
+$ ./bin/rake admin:activate EMAIL=foobar@example.com
 ```
 
 ### Environment Variables

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   web:
-    image: hogelog/dmemo
+    build: .
     env_file: .env.docker
     volumes:
       - ./log/docker:/app/log

--- a/lib/tasks/docker.rake
+++ b/lib/tasks/docker.rake
@@ -1,5 +1,0 @@
-namespace :docker do
-  task :build do
-    sh(*%W(docker build -t hogelog/dmemo:latest .))
-  end
-end


### PR DESCRIPTION
https://hub.docker.com/r/hogelog/dmemo has not been updated since 2021. I personally asked @hogelog and he agreed to remove links to that repository.