### PR TITLE
Add Cookpad to licensers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 hogelog
+Copyright (c) 2016 hogelog & Cookpad Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This repository has been under `cookpad` organization for some time now. Therefore, I've added Cookpad to the licensers.