### PR TITLE
Fix typo of fontawesome class name

### DIFF
--- a/app/views/sessions/new.html.haml
+++ b/app/views/sessions/new.html.haml
@@ -2,5 +2,5 @@
 .content
   %p.lead Required sign in to access Dmemo.
   = button_to google_oauth2_path(return_to: params[:return_to]), class: 'btn btn-secondary', method: :post do
-    %i.fabs.fa-google
+    %i.fab.fa-google
     %span Sign in with Google


### PR DESCRIPTION
Follow-up: https://github.com/cookpad/dmemo/pull/332