### PR TITLE
ci: Avoid running tests twice for pull requests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,9 @@
 name: Ruby
-on: [push,pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 jobs:
   spec:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I noticed the same workflow of GitHub Actions runs twice when opening a pull request.