### PR TITLE
Fix margin of search box when not logined

### DIFF
--- a/app/views/shared/_main_sidebar.html.haml
+++ b/app/views/shared/_main_sidebar.html.haml
@@ -9,14 +9,14 @@
 
   %div.sidebar
     - if current_user
-      .user-panel.mt-3.pb-3.mb-3.d-flex.border-0
+      .user-panel.mt-3.mb-3.d-flex.border-0
         .image
           = image_tag current_user.image_url, class: "rounded"
         .info
           %span.d-block= current_user.name
 
-    = form_with model: @search_result, method: :get, local: true, class: "form-inline" do |f|
-      .input-group.mb-3
+    = form_with model: @search_result, method: :get, local: true, class: "form-inline mt-3 mb-3" do |f|
+      .input-group
         = f.search_field :keyword, placeholder: "Search...", class: "form-control form-control-sidebar"
         .input-group-append
           %button.btn.btn-sidebar{name: "search", type: "submit"}


### PR DESCRIPTION
Added spaces between the logo and the search box

| Before | After |
| -- | -- |
| <img width="251" alt="" src="https://github.com/cookpad/dmemo/assets/4374702/f8b16b60-2d83-4b93-bd7c-98e0746c670d"> | <img width="250" alt="スクリーンショット 2024-04-17 12 04 09" src="https://github.com/cookpad/dmemo/assets/4374702/194f344c-a074-4b42-8e04-7719c1f9cc2a"> |
